### PR TITLE
Remove NLB and non-LB functionality from this script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 	DOTENV_TARGET=.env
 endif
 
-VERSION = 2.8.0
+VERSION = 2.9.0
 IMAGE_NAME ?= amaysim/ecs-utils:$(VERSION)
 TAG = $(VERSION)
 
@@ -27,6 +27,7 @@ shell: $(DOTENV_TARGET)
 lint: $(DOTENV_TARGET)
 	docker-compose run --rm flake8 --ignore 'E501' scripts/*.py
 	docker-compose run --rm pylint scripts/*.py
+	docker-compose run --rm cfn-python-lint cfn-lint -t scripts/ecs-cluster-application-version.yml
 
 test: $(DOTENV_TARGET)
 	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,11 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:Z
       - .:/srv/app:Z
+  cfn-python-lint:
+    image: amaysim/cfn-python-lint:latest
+    network_mode: "none"
+    entrypoint: ''
+    env_file: .env
+    working_dir: /srv/app
+    volumes:
+      - .:/srv/app:Z

--- a/scripts/cutover.py
+++ b/scripts/cutover.py
@@ -105,7 +105,7 @@ def set_correct_service_size(cluster_name, app_name, version_stack_name, target_
     cloudformation = boto3.client('cloudformation')
     response = cloudformation.describe_stack_resources(
         StackName=version_stack_name,
-        LogicalResourceId='ECSServiceLB'
+        LogicalResourceId='ECSService'
     )
     service_full_name = response['StackResources'][0]['PhysicalResourceId'].split('/')[-1]
 
@@ -130,7 +130,7 @@ def wait_for_target_group_size(desired_count, target_group):
     """Waits until a target group has a given number of healthy targets"""
 
     targets = 0
-    timeout = 120
+    timeout =  600
     backoff = 0
     start_time = datetime.datetime.now()
     elapsed_time = elapsed_time = datetime.datetime.now() - start_time

--- a/scripts/ecs-cluster-application-version.yml
+++ b/scripts/ecs-cluster-application-version.yml
@@ -76,28 +76,16 @@ Parameters:
   AlbScheme:
     Description: Is the ALB internal or internet-facing?
     Type: String
-  LBType:
-    Description: Type of load balancer
-    Type: String
-    AllowedValues:
-      - None
-      - ALB
-      - NLB
 
 Conditions:
   isAutoscaling: !Equals [ !Ref Autoscaling, 'Enable']
   isInternal: !Equals
     - !Ref AlbScheme
     - 'internal'
-  isALB: !Equals [!Ref LBType, ALB]
-  isNLB: !Equals [!Ref LBType, NLB]
-  isNoLB: !Equals [!Ref LBType, None]
-  isLB: !Not ["Condition": isNoLB]
 
 Resources:
   ALBTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Condition: isALB
     Properties:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: !Ref HealthCheckPath
@@ -115,7 +103,6 @@ Resources:
 
   ListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: isALB
     Properties:
       Actions:
         - Type: forward
@@ -129,10 +116,9 @@ Resources:
         Fn::ImportValue: !Sub "ecs-${ClusterName}-${Name}-${Environment}-ALBListenerSSL"
       Priority: !Ref RulePriority
 
-  ECSServiceLB:
+  ECSService:
     Type: AWS::ECS::Service
     DependsOn: ListenerRule  # The ECS Service will fail to deploy if the TG is not attached to a LB. This DependsOn fixes this.
-    Condition: isLB
     Properties:
       TaskDefinition: !Ref TaskDefinitionArn
       DesiredCount: 1
@@ -151,16 +137,6 @@ Resources:
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
 
-  # Because DependsOn can't be made conditional, we have to define ECSService twice - one for ALB and one without.
-  ECSServiceNoLB:
-    Type: AWS::ECS::Service
-    Condition: isNoLB
-    Properties:
-      TaskDefinition: !Ref TaskDefinitionArn
-      DesiredCount: 1
-      Cluster:
-        Fn::ImportValue: !Sub "ecs-${ClusterName}-ECSClusterArn"
-
   ServiceScalingTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Condition: isAutoscaling
@@ -171,10 +147,7 @@ Resources:
         - "service/${ECSCluster}/${ServiceName}"
         - ECSCluster:
             "Fn::ImportValue": !Sub "ecs-${ClusterName}-ECSCluster"
-          ServiceName: !If
-            - isNoLB
-            - !GetAtt ECSServiceNoLB.Name
-            - !GetAtt ECSServiceLB.Name
+          ServiceName: !GetAtt ECSService.Name
       RoleARN:
         "Fn::ImportValue": !Sub "ecs-${ClusterName}-ECSAutoscalingRoleArn"
       ScalableDimension: ecs:service:DesiredCount
@@ -210,7 +183,6 @@ Resources:
 
 Outputs:
   Url:
-    Condition: isALB
     Value: !Sub "https://${Name}-${Version}.${Domain}${Path}"
     Description: URL for the version of this app
   Version:

--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -1,2 +1,1 @@
 FROM quay.io/assemblyline/ok:latest
-RUN echo "This is a test Dockerfile"

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   ecs:
-    image: amaysim/ecs-utils:2.7.0
+    image: amaysim/ecs-utils:2.9.0
     env_file: .env
     volumes:
       - .:/srv/app:Z


### PR DESCRIPTION
This commit refactors the deploy.py script to remove functionality,
simplifying it greatly. As part of this, the ability to deploy a
NLB-based service or a service without any kind of load balancer has
been removed.

Additionally, the main deploy function in deploy.py has been split up in
to more functions to make it more readable.

Other changes:
  * Added cfn-python-lint to validate version template
  * Increased cutover timeout (it can take a while if an instance is
terminated during cutover)
  * Remove parameter that determined load balancer type, as well as any
conditionals around having a load balancer