### PR TITLE
Dope 5491 merge with container env vars

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -134,7 +134,10 @@ def upload_task_definition(task_definition):
     print("Generating environment variable configuration...")
     environment = generate_environment_object()
     for index, value in enumerate(task_definition['containerDefinitions']):  # pylint: disable=unused-variable
-        task_definition['containerDefinitions'][index]['environment'] = environment
+        if not 'environment' in task_definition['containerDefinitions'][index]:
+            task_definition['containerDefinitions'][index]['environment'] = {}
+        task_definition['containerDefinitions'][index]['environment'].update(environment)
+
     print("Task definition generated:")
     print(json.dumps(task_definition, indent=2, default=str))
 

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -131,7 +131,8 @@ def update_container_definitions_with_env_vars(task_definition):
         return task_definition
     for index, container_definition in enumerate(task_definition['containerDefinitions']):  # pylint: disable=unused-variable
         if not 'environment' in container_definition:
-            container_definition['environment'] = []
+            container_definition['environment'] = environment
+            continue
         for index_environment, value_environment in enumerate(environment):
             updated = False
             for index_container_environment, value_container_environment in enumerate(container_definition['environment']):

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -129,19 +129,20 @@ def update_container_definitions_with_env_vars(task_definition):
     environment = generate_environment_object()
     if not environment:
         return task_definition
-    for index, container_definition in enumerate(task_definition['containerDefinitions']):  # pylint: disable=unused-variable
+    for container_definition in task_definition['containerDefinitions']:
         if not 'environment' in container_definition:
             container_definition['environment'] = environment
             continue
-        for index_environment, value_environment in enumerate(environment):
-            updated = False
-            for index_container_environment, value_container_environment in enumerate(container_definition['environment']):
-                if value_environment['name'] == value_container_environment['name']:
-                    value_container_environment['value'] = value_environment['value']
-                    updated = True
-                    break
-            if not updated:
-                container_definition['environment'].append(value_environment)
+
+        for env_name_value in environment:
+            env_found_in_definition = False
+            for container_env_name_value in container_definition['environment']:
+                if container_env_name_value['name'] == env_name_value['name']:
+                    container_env_name_value['value'] = env_name_value['value']
+                    env_found_in_definition = True
+
+            if not env_found_in_definition:
+                container_definition['environment'].append(env_name_value)
     return task_definition
 
 def upload_task_definition(task_definition):

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -101,7 +101,7 @@ class GenerateEnvironmentObjectTest(unittest.TestCase):
         environment = deploy.generate_environment_object()
         self.assertEqual(environment, expected_environment)
 
-class MergeTaskDefinitionWithEnvVarsTest(unittest.TestCase):
+class UpdateContainerDefinitionsWithEnvVarsTest(unittest.TestCase):
     """Unit tests for deploy.update_container_definitions_with_env_vars(task_definition)"""
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='ENV\nCLOUD'))

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -101,6 +101,43 @@ class GenerateEnvironmentObjectTest(unittest.TestCase):
         environment = deploy.generate_environment_object()
         self.assertEqual(environment, expected_environment)
 
+class MergeTaskDefinitionWithEnvVarsTest(unittest.TestCase):
+    """Unit tests for deploy.update_container_definitions_with_env_vars(task_definition)"""
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='ENV\nCLOUD'))
+    @patch.dict('os.environ', {'ENV': 'Dev', 'CLOUD': 'AWS'})
+    def test_1(self):
+        """Test with no container environment configured"""
+        # Given
+        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        # When
+        result = deploy.update_container_definitions_with_env_vars(task_definition)
+        # Then
+        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"}, {"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        self.assertEqual(result, expected_task_definition)
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='ENV\nCLOUD'))
+    @patch.dict('os.environ', {'ENV': 'Dev', 'CLOUD': 'AWS'})
+    def test_2(self):
+        """Test with container environment configured"""
+        # Given
+        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"QA"},{"name":"PATH","value":"apath"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        # When
+        result = deploy.update_container_definitions_with_env_vars(task_definition)
+        # Then
+        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"},{"name":"PATH","value":"apath"},{"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        self.assertEqual(result, expected_task_definition)
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data=''))
+    def test_3(self):
+        """Test with no env vars"""
+        # Given
+        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        # When
+        result = deploy.update_container_definitions_with_env_vars(task_definition)
+        # Then
+        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        self.assertEqual(result, expected_task_definition)
 
 def main():
     """Entrypoint for CLI"""

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -109,11 +109,11 @@ class MergeTaskDefinitionWithEnvVarsTest(unittest.TestCase):
     def test_1(self):
         """Test with no container environment configured"""
         # Given
-        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         # When
         result = deploy.update_container_definitions_with_env_vars(task_definition)
         # Then
-        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"}, {"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        expected_task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"}, {"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         self.assertEqual(result, expected_task_definition)
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='ENV\nCLOUD'))
@@ -121,22 +121,34 @@ class MergeTaskDefinitionWithEnvVarsTest(unittest.TestCase):
     def test_2(self):
         """Test with container environment configured"""
         # Given
-        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"QA"},{"name":"PATH","value":"apath"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"QA"},{"name":"PATH","value":"apath"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         # When
         result = deploy.update_container_definitions_with_env_vars(task_definition)
         # Then
-        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"},{"name":"PATH","value":"apath"},{"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        expected_task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"},{"name":"PATH","value":"apath"},{"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         self.assertEqual(result, expected_task_definition)
 
     @patch('builtins.open', unittest.mock.mock_open(read_data=''))
     def test_3(self):
         """Test with no env vars"""
         # Given
-        task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         # When
         result = deploy.update_container_definitions_with_env_vars(task_definition)
         # Then
-        expected_task_definition = {"containerDefinitions":[{"essential":True,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":True},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}
+        expected_task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}}}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
+        self.assertEqual(result, expected_task_definition)
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='ENV\nCLOUD'))
+    @patch.dict('os.environ', {'ENV': 'Dev', 'CLOUD': 'AWS'})
+    def test_4(self):
+        """Test with multiple container definitions"""
+        # Given
+        task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"}]},{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"QA"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
+        # When
+        result = deploy.update_container_definitions_with_env_vars(task_definition)
+        # Then
+        expected_task_definition = json.loads('{"containerDefinitions":[{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"},{"name":"CLOUD","value":"AWS"}]},{"essential":true,"image":"an/image","name":"aname","linuxParameters":{"initProcessEnabled":true},"portMappings":[{"containerPort":1234}],"logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"group","awslogs-region":"aregion"}},"environment":[{"name":"ENV","value":"Dev"},{"name":"CLOUD","value":"AWS"}]}],"family":"afamilly","volumes":[],"memory":"128","cpu":"128"}')
         self.assertEqual(result, expected_task_definition)
 
 def main():


### PR DESCRIPTION
This PR allows environment variables to be defined in the container definitions (`ecs.json`) which can be overridden with environment variables. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html.